### PR TITLE
Support --exclude-exts

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,7 @@
   "bugs": {
     "url": "https://github.com/CSSLint/csslint/issues"
   },
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/CSSLint/csslint/blob/master/LICENSE"
-  },
+  "license": "MIT",
   "main": "./lib/csslint-node.js",
   "bin": {
     "csslint": "./release/npm/cli.js"


### PR DESCRIPTION
Comma-separated list of file extensions to exclude. Can be used to exclude
.min.css files. Implemented very similarly to exclude-list.

/cc @codeclimate/review
